### PR TITLE
Fixed the improper initializing of std::unique_ptr

### DIFF
--- a/DMALibrary/Memory/Shellcode.cpp
+++ b/DMALibrary/Memory/Shellcode.cpp
@@ -49,7 +49,7 @@ uint64_t c_shellcode::find_codecave(size_t function_size, std::string process_na
 		return 0;
 	}
 
-	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t(function_size));
+	auto buffer = std::unique_ptr<uint8_t[]>(new uint8_t[function_size]);
 	if (!mem.Read(codecave, buffer.get(), function_size, pid))
 	{
 		LOG("[!] Could not read codecave for '%s'\n", module.c_str());


### PR DESCRIPTION
Fixed the improper initializing of std::unique_ptr which was causing "CRT detected the application wrote to memory after end of heap buffer"